### PR TITLE
rest_client deprecated

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,8 +4,8 @@
 
 return unless node.serverdensity.enabled
 
-chef_gem 'rest_client'
-require 'rest_client'
+chef_gem 'rest-client'
+require 'rest-client'
 
 case node[:platform]
 


### PR DESCRIPTION
During the bootstrap, the chef-client warns: WARNING: The rest_client gem is deprecated and will be removed from RubyGems. Please use rest-client gem instead.