### PR TITLE
Allow override of AWS devices, update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,8 @@ https://supermarket.getchef.com/cookbooks/serverdensity
   * Modified by: Jonty Wareing <jonty@jonty.co.uk>
   * Modified by: Server Density <hello@serverdensity.com>
   * Rewritten by: Mal Graty <mal.graty@googlemail.com>
+  * Other Contributors:
+    * [Joe Marty](https://github.com/mltsy)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ node['serverdensity']['alerts']['high-load'] = {
 An LWRP is a "Lightweight Resource Provider", or in plain english, an additional resource type you can use in your recipes.  This cookbook provides three such resources:
 
 - `serverdensity`: the default resource for setting up the agent and registering devices, etc.
-- `serverdensity\_alert`: resource for setting up new alerts
-- `serverdensity\_plugin`: resource for installing and configuring plugins
+- `serverdensity_alert`: resource for setting up new alerts
+- `serverdensity_plugin`: resource for installing and configuring plugins
 
 ### serverdensity
 
@@ -220,7 +220,7 @@ end
 
 ##### Finding/creating a device using the API (steps 5 & 6)
 
-If you provide API credentials, this allows steps 5 & 6 to run.  That can be done either by setting the credentials in your attributes (as described under [Basic Config](#basic config)), or by providing the credentials directly to the LWRP:
+If you provide API credentials, this allows steps 5 & 6 to run.  That can be done either by setting the credentials in your attributes (as described under [Basic Config](#basic-config)), or by providing the credentials directly to the LWRP:
 
 API V1:
 ```rb

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -133,8 +133,10 @@ end
 
 def device
   return unless ServerDensity::API.configured?
-  query = if provider.empty?
-    @new_resource.device || @new_resource.name
+  query = if @new_resource.device
+    @new_resource.device
+  elsif provider.empty?
+    @new_resource.name
   else
     provider
   end


### PR DESCRIPTION
- Allow client recipes to override the usage of AWS instance-id as the primary criteria for linking devices
- Update the readme to reflect the change
- Add a table of contents, and more examples and explanations of vague concepts in the readme