### PR TITLE
Chef 12.1.0 Support

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/libraries/api_base.rb
+++ b/libraries/api_base.rb
@@ -49,6 +49,8 @@ module ServerDensity
       private
 
       def request(method, path, payload, options = {}, &block)
+        require 'rest-client'
+
         options[:params] = if options.has_key? :params
           params.merge(options[:params])
         else
@@ -66,6 +68,8 @@ module ServerDensity
       end
 
       def response(res)
+        require 'rest-client'
+
         body = Chef::JSONCompat.from_json(res)
         RestClient::Response.create(body, res.net_http_res, res.args)
       end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,8 +4,10 @@
 
 return unless node.serverdensity.enabled
 
-chef_gem 'rest-client'
-require 'rest-client'
+chef_gem 'rest-client' do
+  action :install
+  compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
+end
 
 case node[:platform]
 

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,7 @@
+describe 'serverdensity::default' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it 'should install the rest-client gem' do
+    expect(chef_run).to install_chef_gem('rest-client')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+current_dir = File.dirname(__FILE__)
+
+RSpec.configure do |config|
+  # Point to the cookbooks directory
+  config.cookbook_path = File.join(current_dir, '../cookbooks')
+end


### PR DESCRIPTION
As per https://www.chef.io/blog/2015/02/17/chef-12-1-0-chef_gem-resource-warnings/ `chef_gem` at compile time is deprecated and throws a warning.