### PR TITLE
Prevent restart without config change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ Gemfile.lock
 bin/*
 .bundle/*
 
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ ChangeLog for chef-serverdensity
 3.0.1 (01-09-2016)
 ------------------
 - Improved recipe to ensure that the sd-agent service is only restarted after a configuration change. 
+- Small template tweaks
+- Better comments in attributes to describe when to use arrays
+- Small fixes to the recipe to point to correct packages and yaml files
+- Removal/update of deprecated features 
+- [Foodcritic](http://www.foodcritic.io/) fixes
 
 3.0.0 (14-04-2016)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ChangeLog for chef-serverdensity
 ================================
+3.0.1 (01-09-2016)
+------------------
+- Improved recipe to ensure that the sd-agent service is only restarted after a configuration change. 
 
 3.0.0 (14-04-2016)
 ------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -108,10 +108,10 @@ default['serverdensity']['postgres_ssl'] = nil
 default['serverdensity']['rabbitmq_api_url'] = nil # Set this attribute to install the RabbitMQ plugin
 default['serverdensity']['rabbitmq_user'] = nil
 default['serverdensity']['rabbitmq_pass'] = nil
-default['serverdensity']['rabbitmq_nodes'] = nil
-default['serverdensity']['rabbitmq_nodes_regexes'] = nil
-default['serverdensity']['rabbitmq_queues'] = nil
-default['serverdensity']['rabbitmq_queues_regexes'] = nil
+default['serverdensity']['rabbitmq_nodes'] = [nil] # Use an array
+default['serverdensity']['rabbitmq_nodes_regexes'] = [nil] # Use an array 
+default['serverdensity']['rabbitmq_queues'] = [nil] # Use an array 
+default['serverdensity']['rabbitmq_queues_regexes'] = [nil] # Use an array
 
 default['serverdensity']['redis_host'] = nil # Set this attribute to install the Redis plugin
 default['serverdensity']['redis_port'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,16 +41,17 @@ default['serverdensity']['apache_status_pass'] = nil
 default['serverdensity']['btrfs_excludes'] = nil # Set this attribute to install the BTRFS plugin
 
 default['serverdensity']['consul_url'] = nil # Set this attribute to install the Consul plugin
-default['serverdensity']['consul_whitelist'] = nil
+default['serverdensity']['consul_checks'] = nil
+default['serverdensity']['consul_whitelist'] = [nil]  # Use an array
 
 default['serverdensity']['couchdb_server'] = nil # Set this attribute to install the CouchDB plugin
 default['serverdensity']['couchdb_user'] = nil
 default['serverdensity']['couchdb_password'] = nil
 default['serverdensity']['couchdb_timeout'] = nil
-default['serverdensity']['couchdb_whitelist'] = nil
-default['serverdensity']['couchdb_blacklist'] = nil
+default['serverdensity']['couchdb_whitelist'] = [nil] # Use an array 
+default['serverdensity']['couchdb_blacklist'] = [nil] # Use an array 
 
-default['serverdensity']['directory'] = nil # Set this attribute to install the Directory plugin (Use an Array)
+default['serverdensity']['directory'] = [nil] # Set this attribute to install the Directory plugin (Use an Array)
 
 default['serverdensity']['docker_root'] = nil # Set this attribute to install the Docker plugin
 default['serverdensity']['docker_url'] = nil
@@ -95,7 +96,7 @@ default['serverdensity']['phpfpm_user'] = nil
 default['serverdensity']['phpfpm_password'] = nil
 
 default['serverdensity']['postfix_directory'] = nil # Set this attribute to install the Postfix plugin
-default['serverdensity']['postfix_queues'] = nil
+default['serverdensity']['postfix_queues'] = [nil] # Use an array 
 
 default['serverdensity']['postgres_host'] = nil # Set this attribute to install the Postgres plugin
 default['serverdensity']['postgres_port'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,12 +50,12 @@ default['serverdensity']['couchdb_timeout'] = nil
 default['serverdensity']['couchdb_whitelist'] = nil
 default['serverdensity']['couchdb_blacklist'] = nil
 
-default['serverdensity']['directory'] = nil # Set this attribute to install the Directory plugin
+default['serverdensity']['directory'] = nil # Set this attribute to install the Directory plugin (Use an Array)
 
 default['serverdensity']['docker_root'] = nil # Set this attribute to install the Docker plugin
 default['serverdensity']['docker_url'] = nil
 
-default['serverdensity']['kafka_c_connect_str'] = nil
+default['serverdensity']['kafka_c_connect_str'] = nil # Set this attribute to install the Kafka Consumer plugin
 default['serverdensity']['kafka_c_zk_connect_str'] = nil 
 default['serverdensity']['kafka_c_zk_timeout'] = nil
 default['serverdensity']['kafka_c_kafka_timeout'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,9 @@ maintainer_email 'hello@serverdensity.com'
 license          'All rights reserved'
 description      'Installs/Configures the v2 Server Density monitoring agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.0'
+version          '3.0.1'
+issues_url       'https://github.com/serverdensity/chef-serverdensity/issues'
+source_url       'https://github.com/serverdensity/chef-serverdensity'
 
 depends 'apt'
 depends 'yum'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -26,7 +26,7 @@ action :configure do
   template.mode 00644
 
   template.variables Chef::Mixin::DeepMerge.merge(
-    node["serverdensity"]["to_hash"],
+    node["serverdensity"].to_hash,
     @new_resource.settings
   )
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -26,7 +26,7 @@ action :configure do
   template.mode 00644
 
   template.variables Chef::Mixin::DeepMerge.merge(
-    node.serverdensity.to_hash,
+    node["serverdensity"]["to_hash"],
     @new_resource.settings
   )
 
@@ -72,7 +72,7 @@ action :sync do
 end
 
 action :update do
-  if node.serverdensity.enabled
+  if node["serverdensity"]["enabled"]
     action_setup
     action_configure
     action_enable
@@ -94,7 +94,7 @@ end
 
 def agent_key
   @agent_key ||= @new_resource.agent_key ||
-    node.serverdensity.agent_key ||
+    node["serverdensity"]["agent_key"] ||
     key_from_file ||
     key_from_ec2 ||
     key_from_api
@@ -155,17 +155,17 @@ end
 
 def metadata
   @metadata ||= {
-    group: node.serverdensity.device_group || 'chef-autodeploy',
-    hostname: node.hostname,
+    group: node["serverdensity"]["device_group"] || 'chef-autodeploy',
+    hostname: node["hostname"],
     name: @new_resource.name
   }.merge(provider).merge(@new_resource.metadata)
 end
 
 def provider
   @provider ||= case
-    when (node.ec2.instance_id rescue false)
+    when (node["ec2"]["instance_id"] rescue false)
       { provider: 'amazon', providerId: node.ec2.instance_id }
-    when (node.opsworks.instance.aws_instance_id rescue false)
+    when (node["opswork"]["instance"]["aws_instance_id"] rescue false)
       { provider: 'amazon', providerId: node.opsworks.instance.aws_instance_id }
     else
       {}

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -101,15 +101,15 @@ def agent_key
 end
 
 def username
-  @new_resource.username || node.serverdensity.username
+  @new_resource.username || node["serverdensity"]["username"]
 end
 
 def password
-  @new_resource.password || node.serverdensity.password
+  @new_resource.password || node["serverdensity"]["password"]
 end
 
 def token
-  @new_resource.token || node.serverdensity.token
+  @new_resource.token || node["serverdensity"]["token"]
 end
 
 # methods

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -7,7 +7,7 @@ def whyrun_supported?
 end
 
 # actions
-
+use_inline_resources
 action :clear do
   converge_by 'delete all existing Server Density alerts for device' do
     @new_resource.updated_by_last_action device.reset

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -165,8 +165,8 @@ def provider
   @provider ||= case
     when (node["ec2"]["instance_id"] rescue false)
       { provider: 'amazon', providerId: node["ec2"]["instance_id"] }
-    when (node["opswork"]["instance"]["aws_instance_id"] rescue false)
-      { provider: 'amazon', providerId: node["opswork"]["instance"]["aws_instance_id"] }
+    when (node["opsworks"]["instance"]["aws_instance_id"] rescue false)
+      { provider: 'amazon', providerId: node["opsworks"]["instance"]["aws_instance_id"] }
     else
       {}
   end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -86,8 +86,8 @@ end
 
 def account
   @account ||= @new_resource.account ||
-    node.serverdensity.account ||
-    node.serverdensity.sd_url.sub(/^https?:\/\//, '')
+    node["serverdensity"]["account"] ||
+    node["serverdensity"]["sd_url"].sub(/^https?:\/\//, '')
 rescue
   nil
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -141,7 +141,7 @@ end
 
 def key_from_ec2
   if node.attribute?(:ec2)
-    validate node.ec2.userdata.split(':').last rescue nil
+    validate node["ec2"]["userdata"].split(':').last rescue nil
   end
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -164,9 +164,9 @@ end
 def provider
   @provider ||= case
     when (node["ec2"]["instance_id"] rescue false)
-      { provider: 'amazon', providerId: node.ec2.instance_id }
+      { provider: 'amazon', providerId: node["ec2"]["instance_id"] }
     when (node["opswork"]["instance"]["aws_instance_id"] rescue false)
-      { provider: 'amazon', providerId: node.opsworks.instance.aws_instance_id }
+      { provider: 'amazon', providerId: node["opswork"]["instance"]["aws_instance_id"] }
     else
       {}
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,7 +15,7 @@ chef_gem 'rest-client' do
     compile_time false if Chef::Resource::ChefGem.method_defined?(:compile_time)
 end
 
-case node[:platform]
+case node["platform"]
 
   when 'debian', 'ubuntu'
     include_recipe 'apt'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,7 +64,7 @@ if node['serverdensity']['apache_status_url']
                   :apache_user => node['serverdensity']['apache_status_user'],
                   :apache_pass => node['serverdensity']['apache_status_pass']
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -78,7 +78,7 @@ if node['serverdensity']['btrfs_excludes']
         variables(
                   :btrfs_excludes => node['serverdensity']['btrfs_excludes'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -94,7 +94,7 @@ if node['serverdensity']['consul_url']
                   :consul_checks => node['serverdensity']['consul_checks'],
                   :consul_whitelist => node['serverdensity']['consul_whitelist'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -113,7 +113,7 @@ if node['serverdensity']['couchdb_server']
                   :couchdb_whitelist => node['serverdensity']['couchdb_whitelist'],
                   :couchdb_blacklist => node['serverdensity']['couchdb_blacklist'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -127,7 +127,7 @@ if node['serverdensity']['directory']
         variables(
                   :directory => node['serverdensity']['directory'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -142,7 +142,7 @@ if node['serverdensity']['docker_root']
                   :docker_root => node['serverdensity']['docker_root'],
                   :docker_url => node['serverdensity']['docker_url'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -162,7 +162,7 @@ if node['serverdensity']['kafka_c_connect_str']
                   :kafka_c_my_consumer => node['serverdensity']['kafka_c_my_consumer'],
                   :kafka_c_my_topic => node['serverdensity']['kafka_c_my_topic'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -176,7 +176,7 @@ if node['serverdensity']['memcache_url']
         variables(
                   :memcache_url => node['serverdensity']['memcache_url'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -196,7 +196,7 @@ if node['serverdensity']['mongo_url']
                   :mongo_ssl_cert_reqs => node['serverdensity']['mongo_ssl_cert_reqs'],
                   :mongo_ssl_ca_certs => node['serverdensity']['mongo_ssl_ca_certs'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -215,7 +215,7 @@ if node['serverdensity']['mysql_server']
                   :mysql_sock => node['serverdensity']['mysql_sock'],
                   :mysql_defaults_file => node['serverdensity']['mysql_defaults_file'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -230,7 +230,7 @@ if node['serverdensity']['nginx_status_url']
                   :nginx_status_url => node['serverdensity']['nginx_status_url'],
                   :nginx_ssl_validation => node['serverdensity']['nginx_ssl_validation'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -248,7 +248,7 @@ if node['serverdensity']['ntp_offset_threshold']
                   :ntp_version => node['serverdensity']['ntp_version'],
                   :ntp_timeout => node['serverdensity']['ntp_timeout'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -266,7 +266,7 @@ if node['serverdensity']['phpfpm_status_url']
                   :phpfpm_user  => node['serverdensity']['phpfpm_user'],
                   :phpfpm_password => node['serverdensity']['phpfpm_password'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -281,7 +281,7 @@ if node['serverdensity']['postfix_directory']
                   :postfix_directory => node['serverdensity']['postfix_directory'],
                   :postfix_queues => node['serverdensity']['postfix_queues'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -300,7 +300,7 @@ if node['serverdensity']['postgres_host']
                   :postgres_dbname => node['serverdensity']['postgres_dbname'],
                   :postgres_ssl => node['serverdensity']['postgres_ssl'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -320,7 +320,7 @@ if node['serverdensity']['rabbitmq_api_url']
                   :rabbitmq_queues => node['serverdensity']['rabbitmq_queues'],
                   :rabbitmq_queues_regexes => node['serverdensity']['rabbitmq_queues_regexes'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -339,7 +339,7 @@ if node['serverdensity']['redis_host']
                   :redis_socket_timeout => node['serverdensity']['redis_socket_timeout'],
                   :redis_slowlog_max_len => node['serverdensity']['redis_slowlog_max_len'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -353,7 +353,7 @@ if node['serverdensity']['riak_url']
         variables(
                   :riak_url=> node['serverdensity']['riak_url'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -372,7 +372,7 @@ if node['serverdensity']['supervisord_name']
                   :supervisord_pass => node['serverdensity']['supervisord_pass'],
                   :supervisord_socket => node['serverdensity']['supervisord_scoket'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end
 
@@ -387,6 +387,6 @@ if node['serverdensity']['varnishstat_path']
                   :varnishstat_path=> node['serverdensity']['varnishstat_path'],
                   :varnishstat_name=> node['serverdensity']['varnishstat_name'],
                   )
-        notifies :reload, 'service[sd-agent]', :delayed
+        notifies :restart, 'service[sd-agent]', :delayed
     end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -91,6 +91,7 @@ if node['serverdensity']['consul_url']
         mode 0644
         variables(
                   :consul_url => node['serverdensity']['consul_url'],
+                  :consul_checks => node['serverdensity']['consul_checks'],
                   :consul_whitelist => node['serverdensity']['consul_whitelist'],
                   )
         notifies :reload, 'service[sd-agent]', :delayed
@@ -285,7 +286,7 @@ if node['serverdensity']['postfix_directory']
 end
 
 if node['serverdensity']['postgres_host']
-    package 'sd-agent-postgres'
+    package 'sd-agent-postgresql'
     template '/etc/sd-agent/conf.d/postgres.yaml' do
         source 'postgres.yaml.erb'
         owner 'sd-agent'
@@ -325,7 +326,7 @@ end
 
 if node['serverdensity']['redis_host']
     package 'sd-agent-redis'
-    template '/etc/sd-agent/conf.d/redis.yaml' do
+    template '/etc/sd-agent/conf.d/redisdb.yaml' do
         source 'redis.yaml.erb'
         owner 'sd-agent'
         group 'sd-agent'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,7 +7,7 @@
 # All rights reserved - Do Not Redistribute
 #
 
-return unless node.serverdensity.enabled
+return unless node["serverdensity"]["enabled"]
 
 chef_gem 'rest-client' do
     version '~> 1.7.3'
@@ -39,7 +39,6 @@ case node[:platform]
       baseurl 'https://archive.serverdensity.com/el/$releasever'
       gpgkey 'https://archive.serverdensity.com/sd-packaging-public.key'
     end
-
 end
 
 package 'sd-agent'
@@ -65,6 +64,7 @@ if node['serverdensity']['apache_status_url']
                   :apache_user => node['serverdensity']['apache_status_user'],
                   :apache_pass => node['serverdensity']['apache_status_pass']
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -78,6 +78,7 @@ if node['serverdensity']['btrfs_excludes']
         variables(
                   :btrfs_excludes => node['serverdensity']['btrfs_excludes'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -92,6 +93,7 @@ if node['serverdensity']['consul_url']
                   :consul_url => node['serverdensity']['consul_url'],
                   :consul_whitelist => node['serverdensity']['consul_whitelist'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -110,6 +112,7 @@ if node['serverdensity']['couchdb_server']
                   :couchdb_whitelist => node['serverdensity']['couchdb_whitelist'],
                   :couchdb_blacklist => node['serverdensity']['couchdb_blacklist'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -123,6 +126,7 @@ if node['serverdensity']['directory']
         variables(
                   :directory => node['serverdensity']['directory'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -137,6 +141,7 @@ if node['serverdensity']['docker_root']
                   :docker_root => node['serverdensity']['docker_root'],
                   :docker_url => node['serverdensity']['docker_url'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -156,6 +161,7 @@ if node['serverdensity']['kafka_c_connect_str']
                   :kafka_c_my_consumer => node['serverdensity']['kafka_c_my_consumer'],
                   :kafka_c_my_topic => node['serverdensity']['kafka_c_my_topic'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -169,6 +175,7 @@ if node['serverdensity']['memcache_url']
         variables(
                   :memcache_url => node['serverdensity']['memcache_url'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -188,6 +195,7 @@ if node['serverdensity']['mongo_url']
                   :mongo_ssl_cert_reqs => node['serverdensity']['mongo_ssl_cert_reqs'],
                   :mongo_ssl_ca_certs => node['serverdensity']['mongo_ssl_ca_certs'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -206,6 +214,7 @@ if node['serverdensity']['mysql_server']
                   :mysql_sock => node['serverdensity']['mysql_sock'],
                   :mysql_defaults_file => node['serverdensity']['mysql_defaults_file'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -220,6 +229,7 @@ if node['serverdensity']['nginx_status_url']
                   :nginx_status_url => node['serverdensity']['nginx_status_url'],
                   :nginx_ssl_validation => node['serverdensity']['nginx_ssl_validation'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -237,6 +247,7 @@ if node['serverdensity']['ntp_offset_threshold']
                   :ntp_version => node['serverdensity']['ntp_version'],
                   :ntp_timeout => node['serverdensity']['ntp_timeout'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -254,6 +265,7 @@ if node['serverdensity']['phpfpm_status_url']
                   :phpfpm_user  => node['serverdensity']['phpfpm_user'],
                   :phpfpm_password => node['serverdensity']['phpfpm_password'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -268,6 +280,7 @@ if node['serverdensity']['postfix_directory']
                   :postfix_directory => node['serverdensity']['postfix_directory'],
                   :postfix_queues => node['serverdensity']['postfix_queues'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -286,6 +299,7 @@ if node['serverdensity']['postgres_host']
                   :postgres_dbname => node['serverdensity']['postgres_dbname'],
                   :postgres_ssl => node['serverdensity']['postgres_ssl'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -305,6 +319,7 @@ if node['serverdensity']['rabbitmq_api_url']
                   :rabbitmq_queues => node['serverdensity']['rabbitmq_queues'],
                   :rabbitmq_queues_regexes => node['serverdensity']['rabbitmq_queues_regexes'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -323,6 +338,7 @@ if node['serverdensity']['redis_host']
                   :redis_socket_timeout => node['serverdensity']['redis_socket_timeout'],
                   :redis_slowlog_max_len => node['serverdensity']['redis_slowlog_max_len'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -336,6 +352,7 @@ if node['serverdensity']['riak_url']
         variables(
                   :riak_url=> node['serverdensity']['riak_url'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -354,6 +371,7 @@ if node['serverdensity']['supervisord_name']
                   :supervisord_pass => node['serverdensity']['supervisord_pass'],
                   :supervisord_socket => node['serverdensity']['supervisord_scoket'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
 end
 
@@ -368,10 +386,6 @@ if node['serverdensity']['varnishstat_path']
                   :varnishstat_path=> node['serverdensity']['varnishstat_path'],
                   :varnishstat_name=> node['serverdensity']['varnishstat_name'],
                   )
+        notifies :reload, 'service[sd-agent]', :delayed
     end
-end
-
-service 'sd-agent' do
-    supports [:start, :stop, :restart]
-    action :restart
 end

--- a/templates/default/consul.yaml.erb
+++ b/templates/default/consul.yaml.erb
@@ -3,10 +3,10 @@ init_config:
 
 instances:
     # Where your Consul HTTP Server Lives
-    - url: <%=  @consul_url -%>
+    - url: <%=  @consul_url %>
 
       # Whether to perform checks against the Consul service Catalog
-      catalog_checks: <%=  @consul_checks -%>
+      catalog_checks: <%=  @consul_checks %>
 
 <%- if @consul_whitelist -%> 
       # Services to restrict catalog querying to

--- a/templates/default/directory.yaml.erb
+++ b/templates/default/directory.yaml.erb
@@ -19,22 +19,10 @@ instances:
   # "recursive" - boolean, when true the stats will recurse into directories. default False
 <%- if @directory -%>  
     <% @directory.each  do |item| %>
-  - directory: "<%= "#{item}" %>"
+  - directory: "<%= item %>"
     # name: "tag_value"
     # filegauges: False
     # pattern: "*.log"
     # recursive: True
-    <%  end %>
-<%- end -%> 
-
-<%- if @directory -%>  
-    <% @directory.each  do |item| %>
-    <% @item.each  do |dir| %>
-  - directory: "<%= "#{dir}" %>"
-    name: "<%= "#{dir}" %>"
-    filegauges: <%= "#{dir}" %>
-    pattern: "<%= "#{dir}" %>""
-    recursive: <%= "#{dir}" %>
-    <%  end %>
     <%  end %>
 <%- end -%> 

--- a/templates/default/mongo.yaml.erb
+++ b/templates/default/mongo.yaml.erb
@@ -3,6 +3,9 @@ init_config:
 instances:
   - server: <%= @mongo_url %>
 <%- if @mongo_ssl -%>
+    timeout: <%= @mongo_timeout %>
+<%- end -%>  
+<%- if @mongo_ssl -%>
     ssl: <%= @mongo_ssl %>
 <%- if @mongo_ssl_keyfile -%>
     ssl_keyfile: <%= @mongo_ssl_keyfile %>

--- a/templates/default/mongo.yaml.erb
+++ b/templates/default/mongo.yaml.erb
@@ -2,7 +2,7 @@ init_config:
 
 instances:
   - server: <%= @mongo_url %>
-<%- if @mongo_ssl -%>
+<%- if @mongo_timeout -%>
     timeout: <%= @mongo_timeout %>
 <%- end -%>  
 <%- if @mongo_ssl -%>

--- a/templates/default/postgres.yaml.erb
+++ b/templates/default/postgres.yaml.erb
@@ -1,21 +1,17 @@
 init_config:
 
 instances:
-  - host: <%=  @postgres_host -%>
-  
-    port: <%=  @postgres_port -%>
+  - host: <%=  @postgres_host %>
+    port: <%=  @postgres_port%>
 <%- if @postgres_user -%>     
-    username: <%=  @postgres_user -%>
+    username: <%=  @postgres_user %>
 <%- end -%>
-
 <%- if @postgres_password -%>      
-    password: <%=  @postgres_password -%>
+    password: <%=  @postgres_password %>
 <%- end -%>  
-
 <%- if @postgres_dbname -%>  
-    dbname: <%=  @postgres_dbname -%>
+    dbname: <%=  @postgres_dbname %>
 <%- end -%>    
-
 <%- if @postgres_ssl -%>  
-    ssl: <%=  @postgres_ssl -%>
+    ssl: <%=  @postgres_ssl %>
 <%- end -%>      

--- a/templates/default/rabbitmq.yaml.erb
+++ b/templates/default/rabbitmq.yaml.erb
@@ -4,15 +4,15 @@ instances:
   # A 'rabbitmq_api_url' must be provided, pointing to the api url of the
   # RabbitMQ Managment Plugin (http://www.rabbitmq.com/management.html)
   # optional: 'rabbitmq_user' (default: guest) and 'rabbitmq_pass' (default: guest)
-  - rabbitmq_api_url: <%=  @rabbitmq_api_url -%>
-    rabbitmq_user: <%=  @rabbitmq_user -%>
-    rabbitmq_pass: <%=  @rabbitmq_pass -%>
+  - rabbitmq_api_url: <%=  @rabbitmq_api_url %>
+    rabbitmq_user: <%=  @rabbitmq_user %>
+    rabbitmq_pass: <%=  @rabbitmq_pass %>
     # If you have less than 3 nodes, you don't have to set the nodes parameters
     # All nodes metrics will be collected
     # If you have more than 3 nodes: you can set 3 node names. Metrics will be collected
     # for these nodes. For the other nodes, aggregate will be calculated.
     #
-    <%- if @rabbitmq_nodes -%>    
+    <%- if @rabbitmq_nodes -%>
     nodes:
     <% @rabbitmq_nodes.each  do |item| %>
       <%= "- #{item}" %>

--- a/templates/default/rabbitmq.yaml.erb
+++ b/templates/default/rabbitmq.yaml.erb
@@ -4,7 +4,7 @@ instances:
   # A 'rabbitmq_api_url' must be provided, pointing to the api url of the
   # RabbitMQ Managment Plugin (http://www.rabbitmq.com/management.html)
   # optional: 'rabbitmq_user' (default: guest) and 'rabbitmq_pass' (default: guest)
-  - rabbitmq_api_url: 
+  - rabbitmq_api_url: <%=  @rabbitmq_api_url -%>
     rabbitmq_user: <%=  @rabbitmq_user -%>
     rabbitmq_pass: <%=  @rabbitmq_pass -%>
     # If you have less than 3 nodes, you don't have to set the nodes parameters


### PR DESCRIPTION
This PR prevents the cookbook from restarting the sd-agent service on a chef run unless a new plugin has been installed or the configuration has been changed. 

Also included are:
- Small template tweaks
- Better comments in attributes to describe when to use arrays
- Small fixes to the recipe to point to correct packages and yaml files
- Removal/update of deprecated features 
- [Foodcritic](http://www.foodcritic.io/) fixes

@carlosperello please can you review this? 