### PR TITLE
Prevent empty array installing sd-agent-directory

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -117,7 +117,7 @@ if node['serverdensity']['couchdb_server']
     end
 end
 
-if node['serverdensity']['directory']
+if !node['serverdensity']['directory'].empty?
     package 'sd-agent-directory'
     template '/etc/sd-agent/conf.d/directory.yaml' do
         source 'directory.yaml.erb'


### PR DESCRIPTION
Prevents the default empty directory array from installing the directory plugin. 