### PR TITLE
Elastic timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog for chef-serverdensity
 ================================
+3.0.5 (04-10-2016)
+------------------
+- Added `timeout` option for Elasticsearch plugin 
+
 3.0.4 (29-09-2016)
 ------------------
 - Added Elasticsearch support 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,6 +65,7 @@ default['serverdensity']['elastic_pending_task_stats'] = nil
 default['serverdensity']['elastic_ssl_verify'] = nil
 default['serverdensity']['elastic_ssl_cert'] = nil
 default['serverdensity']['elastic_ssl_key'] = nil
+default['serverdensity']['elastic_timeout'] = nil
 
 default['serverdensity']['haproxy_url'] = nil # Set this attribute to install the HAProxy Plugin
 default['serverdensity']['haproxy_username'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hello@serverdensity.com'
 license          'All rights reserved'
 description      'Installs/Configures the v2 Server Density monitoring agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.4'
+version          '3.0.5'
 issues_url       'https://github.com/serverdensity/chef-serverdensity/issues'
 source_url       'https://github.com/serverdensity/chef-serverdensity'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -162,7 +162,8 @@ if node['serverdensity']['elastic_url']
                   :elastic_pending_task_stats => node['serverdensity']['elastic_pending_task_stats'],
                   :elastic_ssl_verify => node['serverdensity']['elastic_ssl_verify'],
                   :elastic_ssl_cert => node['serverdensity']['elastic_ssl_cert'],
-                  :elastic_ssl_key => node['serverdensity']['elastic_ssl_key'], 
+                  :elastic_ssl_key => node['serverdensity']['elastic_ssl_key'],
+                  :elastic_timeout => node['serverdensity']['elastic_timeout'], 
                   )
         notifies :restart, 'service[sd-agent]', :delayed
     end

--- a/templates/default/elastic.yaml.erb
+++ b/templates/default/elastic.yaml.erb
@@ -46,4 +46,7 @@ instances:
     ssl_verify: <%= @elastic_ssl_verify %>
     ssl_cert: <%= @elastic_ssl_cert %>
     ssl_key: <%= @elastic_ssl_key %>
+<% end %>
+<% if @elastic_timeout %>   
+    timeout: <%= @elastic_timeout %>
 <% end %> 


### PR DESCRIPTION
Adds the `timeout` option to the elasticsearch plugin. 

Tested with a chef-solo run. Creates valid yaml. 