### PR TITLE
Update for new deb repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ChangeLog for chef-serverdensity
 ================================
+3.1.0 (22-11-2017)
+------------------
+- Added support for new deb repositories
+- Added support for el6 python27 dependency
+- Ensured Amazon linux only install el6 packages
+
 3.0.7 (10-01-2017)
 ------------------
 - Added support for Couchbase plugin

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Requirements
 - Oracle
 - Scientific
 
+> Support for Ubuntu Precise is now deprecated and agent updates are no longer provided after 2.1.6. This cookbook will install agent 2.1.6 for any server detected as Ubuntu Precise
+
 Attributes
 ----------
 #### serverdensity::default

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hello@serverdensity.com'
 license          'All rights reserved'
 description      'Installs/Configures the v2 Server Density monitoring agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.7'
+version          '3.1.0'
 issues_url       'https://github.com/serverdensity/chef-serverdensity/issues'
 source_url       'https://github.com/serverdensity/chef-serverdensity'
 


### PR DESCRIPTION
This PR updates the chef cookbook to use the new deb repositories for sd-agent: 

```
# cat /etc/apt/sources.list.d/serverdensity.list 
deb      "https://archive.serverdensity.com/ubuntu/" xenial main
# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=16.04
DISTRIB_CODENAME=xenial
DISTRIB_DESCRIPTION="Ubuntu 16.04.3 LTS"
```

```
# cat /etc/apt/sources.list.d/serverdensity.list 
deb      "https://archive.serverdensity.com/ubuntu/" trusty main
# cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=14.04
DISTRIB_CODENAME=trusty
DISTRIB_DESCRIPTION="Ubuntu 14.04.5 LTS"
```

```
# cat /etc/apt/sources.list.d/serverdensity.list 
deb      "https://archive.serverdensity.com/debian/" jessie main   
# cat /etc/debian_version 
8.9
```

This also installs the epel and ius repositories for the el6 agent, as we're only allowing python 2.7 (which needs to come from ius - epel is a dependency for ius).

@carlosperello please can you review? 