### PR TITLE
Use el6 repository for Amazon Linux

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,14 +45,9 @@ case node["platform"]
       allow false
     end
 
-  when 'centos', 'redhat', 'amazon', 'scientific', 'oracle'
+  when 'centos', 'redhat', 'scientific', 'oracle'
     major = node['platform_version'].to_i
     if major == 6
-      if node[:kernel][:machine] == "i686"
-         rpm_arch = "i386"
-      else
-         rpm_arch = node[:kernel][:machine]
-      end
       remote_file "#{Chef::Config[:file_cache_path]}/epel-release-latest.noarch.rpm" do
         source "https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm"
         notifies :install, "rpm_package[epel-release]", :immediately
@@ -83,9 +78,18 @@ case node["platform"]
         action :nothing
       end
     end
+
     yum_repository 'serverdensity' do
       description 'Server Density sd-agent'
       baseurl 'https://archive.serverdensity.com/el/$releasever'
+      gpgkey 'https://archive.serverdensity.com/sd-packaging-public.key'
+    end
+
+  when 'amazon'
+
+    yum_repository 'serverdensity' do
+      description 'Server Density sd-agent'
+      baseurl 'https://archive.serverdensity.com/el/6'
       gpgkey 'https://archive.serverdensity.com/sd-packaging-public.key'
     end
 end


### PR DESCRIPTION
This PR sets the el 6 repository for amazon linux. Tested on `Amazon Linux AMI release 2017.09` with chef-solo: 


```
# chef-solo -c solo.rb -j web.json
Starting Chef Client, version 12.17.44
resolving cookbooks for run list: ["serverdensity"]
Synchronizing Cookbooks:
  - serverdensity (3.0.7)
  - yum (5.1.0)
  - apt (6.1.4)
  - dpkg_autostart (0.2.0)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 17 resources
Recipe: serverdensity::default
  * chef_gem[rest-client] action install (up to date)
  * yum_repository[serverdensity] action create
    * template[/etc/yum.repos.d/serverdensity.repo] action create
      - create new file /etc/yum.repos.d/serverdensity.repo
      - update content in file /etc/yum.repos.d/serverdensity.repo from none to c0556c
      --- /etc/yum.repos.d/serverdensity.repo	2017-12-06 16:38:59.380883000 +0000
      +++ /etc/yum.repos.d/.chef-serverdensity20171206-4294-lhmigo.repo	2017-12-06 16:38:59.380883000 +0000
      @@ -1 +1,10 @@
      +# This file was generated by Chef
      +# Do NOT modify this file by hand.
      +
      +[serverdensity]
      +name=Server Density sd-agent
      +baseurl=https://archive.serverdensity.com/el/6
      +enabled=1
      +gpgcheck=1
      +gpgkey=https://archive.serverdensity.com/sd-packaging-public.key
      - change mode from '' to '0644'
```

@carlosperello please can you review? 