### PR TITLE
bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ChangeLog for chef-serverdensity
 ================================
+3.2.0 (09-05-2018)
+------------------
+- Simplifies device lookup/creation via the Server Density API.
+- Adds support for Chef 13.
+
+3.1.1 (09-05-2018)
+------------------
+- Adds the option to set `min_collection_interval` for the currently available plugins.
+
 3.1.0 (22-11-2017)
 ------------------
 - Added support for new deb repositories

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hello@serverdensity.com'
 license          'MIT'
 description      'Installs/Configures the v2 Server Density monitoring agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.1'
+version          '3.2.0'
 issues_url       'https://github.com/serverdensity/chef-serverdensity/issues'
 source_url       'https://github.com/serverdensity/chef-serverdensity'
 chef_version     '>= 12.5' if respond_to?(:chef_version)


### PR DESCRIPTION
This PR bumps the version in `metadata.rb` and updates `CHANGELOG.md`. 

Required to allow the latest version to be released to supermarket. 

@NassimHC please can you review? 