### PR TITLE
Fix bionic and add version attr

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,7 @@ default['serverdensity']['agent_key'] = nil
 default['serverdensity']['enabled'] = true
 default['serverdensity']['sd_account'] = nil
 default['serverdensity']['token'] = nil
+default['serverdensity']['version'] = nil
 
 default['serverdensity']['plugin_dir'] = '/etc/sd-agent/plugins'
 default['serverdensity']['plugin_options'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -16,6 +16,8 @@ case node["platform"]
     include_recipe 'apt'
 
     case node['lsb']['codename'].downcase
+      when 'bionic'
+        node.run_state['repo_dist'] = 'bionic'
       when 'artful', 'yakkety', 'xenial', 'zesty'
         node.run_state['repo_dist'] = 'xenial'
       when 'trusty', 'utopic', 'vivid', 'wily'
@@ -89,7 +91,9 @@ case node["platform"]
     end
 end
 
-package 'sd-agent'
+package 'sd-agent' do
+  version node['serverdensity']['version']
+end
 
 service 'sd-agent' do
   supports [:start, :stop, :restart]


### PR DESCRIPTION
This PR fix sd-agent deployment on Ubuntu-18.04. In addition, I added the ability to specify package version, because I need force my environments to use the same version everywhere.