### PR TITLE
Add TCP plugin support, fix docker plugin config name, add config options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog for chef-serverdensity
 ================================
+3.2.3 (20-12-2018)
+------------------
+- Fix and improve docker daemon plugin configs.
+
 3.2.2 (15-10-2018)
 ------------------
 - Adds support for Ubuntu Cosmic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ ChangeLog for chef-serverdensity
 ================================
 3.2.3 (20-12-2018)
 ------------------
-- Fix and improve docker daemon plugin configs.
+- Fixed and improved docker daemon plugin configs.
+- Added support for TCP plugin
 
 3.2.2 (15-10-2018)
 ------------------

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This cookbook installs the v2 [Server Density](http://www.serverdensity.com/) ag
 * sd-agent-redis
 * sd-agent-riak
 * sd-agent-supervisord
+* sd-agent-tcp-check
 * sd-agent-varnish
 * sd-agent-zookeeper
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,12 @@ License and Authors
 * Modified by: Server Density <hello@serverdensity.com>
 * Rewritten by: Mal Graty <mal.graty@googlemail.com>
 * Other Contributors:
-* [Joe Marty](https://github.com/mltsy)
+  * [Joe Marty](https://github.com/mltsy)
 
 * Rewritten by: Server Density <hello@serverdensity.com>
 * Other Contributors:
-* [Thijs Cramer](https://github.com/FireDrunk)
+  * [Thijs Cramer](https://github.com/FireDrunk)
+  * [Nikolay Antsiferov](https://github.com/Nklya)
 
 ## License
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -64,8 +64,13 @@ default['serverdensity']['couchdb_collection_interval'] = '0'
 default['serverdensity']['directory'] = [] # Set this attribute to install the Directory plugin (Use an Array)
 
 default['serverdensity']['docker_root'] = nil # Set this attribute to install the Docker plugin
-default['serverdensity']['docker_url'] = nil
+default['serverdensity']['docker_url'] = 'unix://var/run/docker.sock'
 default['serverdensity']['docker_collection_interval'] = '0'
+default['serverdensity']['collect_container_count'] = false
+default['serverdensity']['collect_container_size'] = false
+default['serverdensity']['collect_volume_count'] = false
+default['serverdensity']['collect_images_stats'] = false
+default['serverdensity']['collect_image_size'] = false
 
 default['serverdensity']['elastic_url'] = nil # Set this attribute to install the Elasticsearch plugin
 default['serverdensity']['elastic_username'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -179,6 +179,23 @@ default['serverdensity']['supervisord_pass'] = nil
 default['serverdensity']['supervisord_socket'] = nil
 default['serverdensity']['supervisord_collection_interval'] = '0'
 
+# You need to define array of hashes with all checks you need
+# i.e.
+# default['serverdensity']['tcp_checks'] = [
+#   { # Long form
+#     name: 'Check localhost 22 port',
+#     host: 'localhost',
+#     port: 22,
+#     timeout: 5,
+#     collect_response_time: true,
+#   },
+#   { # Short form
+#     host: 'localhost',
+#     port: 80,
+#   },
+# ]
+default['serverdensity']['tcp_checks'] = nil # Set this attribute to install the TCP plugin
+
 default['serverdensity']['varnishstat_path'] = nil # Set this attribute to install the Varnish plugin
 default['serverdensity']['varnishstat_name'] = nil
 default['serverdensity']['varnishstat_collection_interval'] = '0'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -179,8 +179,7 @@ default['serverdensity']['supervisord_pass'] = nil
 default['serverdensity']['supervisord_socket'] = nil
 default['serverdensity']['supervisord_collection_interval'] = '0'
 
-# You need to define array of hashes with all checks you need
-# i.e.
+# You need to define array of hashes with all checks you need, for example:
 # default['serverdensity']['tcp_checks'] = [
 #   { # Long form
 #     name: 'Check localhost 22 port',

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hello@serverdensity.com'
 license          'MIT'
 description      'Installs/Configures the v2 Server Density monitoring agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.2.2'
+version          '3.2.3'
 issues_url       'https://github.com/serverdensity/chef-serverdensity/issues'
 source_url       'https://github.com/serverdensity/chef-serverdensity'
 chef_version     '>= 12.5' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -273,7 +273,7 @@ end
 
 if node['serverdensity']['docker_root']
     package 'sd-agent-docker'
-    template '/etc/sd-agent/conf.d/docker.yaml' do
+    template '/etc/sd-agent/conf.d/docker_daemon.yaml' do
         source 'docker.yaml.erb'
         owner 'sd-agent'
         group 'sd-agent'
@@ -282,6 +282,11 @@ if node['serverdensity']['docker_root']
                   :docker_root => node['serverdensity']['docker_root'],
                   :docker_url => node['serverdensity']['docker_url'],
                   :docker_collection_interval => node['serverdensity']['docker_collection_interval'],
+                  :collect_container_count => node['serverdensity']['collect_container_count'],
+                  :collect_container_size => node['serverdensity']['collect_container_size'],
+                  :collect_volume_count => node['serverdensity']['collect_volume_count'],
+                  :collect_images_stats => node['serverdensity']['collect_images_stats'],
+                  :collect_image_size => node['serverdensity']['collect_image_size'],
                   )
         notifies :restart, 'service[sd-agent]', :delayed
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -606,6 +606,20 @@ if node['serverdensity']['supervisord_name']
     end
 end
 
+if node['serverdensity']['tcp_checks']
+      package 'sd-agent-tcp-check'
+      template '/etc/sd-agent/conf.d/tcp_check.yaml' do
+          source 'tcp_check.yaml.erb'
+          owner 'sd-agent'
+          group 'sd-agent'
+          mode 0644
+          variables(
+                    :tcp_checks => node['serverdensity']['tcp_checks'],
+                    )
+          notifies :restart, 'service[sd-agent]', :delayed
+      end
+  end
+
 if node['serverdensity']['varnishstat_path']
     package 'sd-agent-varnish'
     template '/etc/sd-agent/conf.d/varnish.yaml' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -273,6 +273,12 @@ end
 
 if node['serverdensity']['docker_root']
     package 'sd-agent-docker'
+    # Add sd-agent to docker group (Docker plugin needs it)
+    group 'docker' do
+        members 'sd-agent'
+        append true
+        action :modify
+    end
     template '/etc/sd-agent/conf.d/docker_daemon.yaml' do
         source 'docker.yaml.erb'
         owner 'sd-agent'

--- a/templates/default/docker.yaml.erb
+++ b/templates/default/docker.yaml.erb
@@ -1,3 +1,5 @@
+# This file is managed by Chef. Any modifications will be lost.
+
 # Warning
 # The user running the Server Density Agent (usually "sd-agent") must be part of the "docker" group
 

--- a/templates/default/docker.yaml.erb
+++ b/templates/default/docker.yaml.erb
@@ -8,10 +8,43 @@ init_config:
   docker_root: <%= @docker_root %>
 
   # Timeout on Docker socket connection. You may have to increase it if you have many containers.
-  # socket_timeout: 5
-  
+  # timeout: 5
+
+  # How often the check should run. If this is not specified it will default to 0 which will run the check on every
+  # collector run (every 60s). If the value is less than 60 this will cause the check to be run on every collector run.
   min_collection_interval: <%= @docker_collection_interval %>
 
 instances:
-    # URL of the Docker daemon socket to reach the Docker API. HTTP also works.
+  # URL of the Docker daemon socket to reach the Docker API. HTTP also works.
   - url: "<%= @docker_url %>"
+
+    # Collect the container count tagged by state (running, paused, exited, dead)
+    # Defaults to false.
+    #
+    collect_container_count: <%= @collect_container_count %>
+
+    # Collect disk usage per container with docker.container.size_rw and
+    # docker.container.size_rootfs metrics.
+    # Warning: This might take time for Docker daemon to generate,
+    # ensure that `docker ps -a -q` run fast before enabling it.
+    # Defaults to false.
+    #
+    collect_container_size: <%= @collect_container_size %>
+
+    # Collect the volume count for attached and dangling volumes.
+    # Defaults to false.
+    #
+    collect_volume_count: <%= @collect_volume_count %>
+
+    # Collect images stats
+    # Number of available active images and intermediate images as gauges.
+    # Defaults to false.
+    #
+    collect_images_stats: <%= @collect_images_stats %>
+
+    # Collect disk usage per image with docker.image.size and docker.image.virtual_size metrics.
+    # The check gets this size with the `docker images` command.
+    # Requires collect_images_stats to be enabled.
+    # Defaults to false.
+    #
+    collect_image_size: <%= @collect_image_size %>

--- a/templates/default/tcp_check.yaml.erb
+++ b/templates/default/tcp_check.yaml.erb
@@ -1,0 +1,14 @@
+# This file is managed by Chef. Any modifications will be lost.
+
+init_config:
+
+instances:
+  <% @tcp_checks.each do |check| %>
+  - name: <%= check['name'] || "Check #{check['host']}:#{check['port']}" %>
+    host: <%= check['host'] %>
+    port: <%= check['port'] %>
+    collect_response_time: <%= check['collect_response_time'] || false %>
+    <% if check['timeout'] %>
+    timeout: <%= check['timeout'] %>
+    <% end %>
+  <% end %>


### PR DESCRIPTION
Hello.

I've found that docker plugin has changed and config name is different.
So I fixed it and added a couple of reasonable options.
And also I added support for TCP plugin checks. I think this is a useful option.

All are tested and working in my environment.

* Add TCP plugin support
* Fix docker plugin config name
* Add new options (disabled by default)
* Set docker_url to default Docker socket
* Add sd-agent to docker group
* Bump version

@carlosperello Could you please review?