### PR TITLE
Fix log_to_syslog option, delete default listen_port value, fix links to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog for chef-serverdensity
 ================================
+3.2.5 (14-02-2019)
+------------------
+- Fix log_to_syslog option, delete default listen_port value
+
 3.2.4 (10-01-2019)
 ------------------
 - Fixed error when docker group doesn't exist

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,11 +26,11 @@ default['serverdensity']['hostname'] = nil
 default['serverdensity']['collector_log_file'] = '/var/log/sd-agent/collector.log'
 default['serverdensity']['forwarder_log_file'] = '/var/log/sd-agent/forwarder.log'
 
-default['serverdensity']['log_to_syslog'] = 'yes'
+default['serverdensity']['log_to_syslog'] = false
 default['serverdensity']['syslog_host'] = nil
 default['serverdensity']['syslog_port'] = nil
 
-default['serverdensity']['listen_port'] = '17124'
+default['serverdensity']['listen_port'] = nil
 
 default['serverdensity']['device_group'] = nil
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'hello@serverdensity.com'
 license          'MIT'
 description      'Installs/Configures the v2 Server Density monitoring agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.2.4'
+version          '3.2.5'
 issues_url       'https://github.com/serverdensity/chef-serverdensity/issues'
 source_url       'https://github.com/serverdensity/chef-serverdensity'
 chef_version     '>= 12.5' if respond_to?(:chef_version)

--- a/templates/default/agent.cfg.erb
+++ b/templates/default/agent.cfg.erb
@@ -1,6 +1,6 @@
 #
 # Server Density Agent Config
-# See http://www.serverdensity.com/docs/agent/configvariables/
+# See https://support.serverdensity.com/hc/en-us/articles/360001065303-Agent-configuration-options
 
 [Main]
 sd_account: <%= @sd_account %>
@@ -29,18 +29,17 @@ proxy_forbid_method_switch: <%= @proxy_forbid_method_switch %>
 hostname: <%= @hostname %>
 <% end %>
 <% if @plugin_dir %>
-#
+# ========================================================================== #
 # Plugins
-#
-# Leave blank to ignore.
-# See https://support.serverdensity.com/hc/en-us/articles/213074438-Information-about-Custom-Plugins
-#
+# See https://support.serverdensity.com/hc/en-us/articles/360001082746
+# ========================================================================== #
+
 plugin_directory: <%= @plugin_dir  %>
 <% end %>
 <% if @log_level %>
 # ========================================================================== #
 # Logging
-# See https://support.serverdensity.com/hc/en-us/articles/213093038-Log-levels-agent-debug-mode
+# See https://support.serverdensity.com/hc/en-us/articles/360001065503
 # ========================================================================== #
 
 log_level: <%= @log_level %>
@@ -53,11 +52,9 @@ collector_log_file: <%= @collector_log_file %>
 <% if @forwarder_log_file %>
 forwarder_log_file: <%= @forwarder_log_file %>
 <% end %>
-<% if @log_to_syslog %>
 # if syslog is enabled but a host and port are not set, a local domain socket
 # connection will be attempted
 log_to_syslog: <%= @log_to_syslog %>
-<% end %>
 <% if @syslog_host %>
 syslog_host: <%= @syslog_host %>
 <% end %>


### PR DESCRIPTION
Hello.

This PR:
* Fix log_to_syslog option,
* delete default listen_port value,
* fix links to documentation
* add changelog,
* bump version

Note: log_to_syslog will work starting from 2.2.4 version of sd-agent

P.S. I have to change the template for log_to_syslog because of sd_agent by default enable logging to syslog https://github.com/serverdensity/sd-agent/blob/master/config.py#L1240